### PR TITLE
Add simple MEO-controlled LEO routing example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # MEO_LEO_cluster_routing
-这是一个由MEO控制的LEO路由算法
+
+这是一个简化的示例，演示如何在MEO卫星控制下对LEO卫星进行路由。
+
+代码位于 `src/` 目录，主要模块如下：
+
+- `satellites.py`：定义了 MEO 与 LEO 卫星的数据结构；
+- `environment.py`：包含选取最近且负载满足条件的 LEO 等基础方法；
+- `rl_agent.py`：简单的 Q-Learning 实现，用于根据全局信息生成路由策略；
+- `routing.py`：给定源 LEO 与目的 LEO，结合 RLAgent 计算路由路径；
+- `main.py`：构建一个小规模示例网络并输出路由结果。
+
+运行示例：
+
+```bash
+python -m src.main
+```
+
+该示例会从地面站选取合适的 LEO 卫星，然后通过 MEO 卫星获得的强化学习策略计算到目标 LEO 的路由路径。

--- a/src/environment.py
+++ b/src/environment.py
@@ -1,0 +1,33 @@
+from typing import Dict, Tuple, List
+import math
+
+from .satellites import LEOSatellite, MEOSatellite
+
+
+def distance(pos1: Tuple[float, float, float], pos2: Tuple[float, float, float]) -> float:
+    """Compute Euclidean distance between two 3D points."""
+    return math.sqrt(sum((a - b) ** 2 for a, b in zip(pos1, pos2)))
+
+
+def find_nearest_available_leo(
+    ground_pos: Tuple[float, float, float],
+    leos: Dict[int, LEOSatellite],
+    load_threshold: int,
+) -> LEOSatellite:
+    """Return the nearest LEO with load below threshold."""
+    candidates = [leo for leo in leos.values() if leo.load < load_threshold]
+    if not candidates:
+        raise ValueError("No available LEO satellite")
+    return min(candidates, key=lambda l: distance(ground_pos, (l.latitude, l.longitude, l.altitude)))
+
+
+def get_leo_by_id(leos: Dict[int, LEOSatellite], leo_id: int) -> LEOSatellite:
+    if leo_id not in leos:
+        raise ValueError(f"LEO {leo_id} not found")
+    return leos[leo_id]
+
+
+def get_meo_by_id(meos: Dict[int, MEOSatellite], meo_id: int) -> MEOSatellite:
+    if meo_id not in meos:
+        raise ValueError(f"MEO {meo_id} not found")
+    return meos[meo_id]

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,44 @@
+"""Example simulation of MEO controlled LEO routing."""
+import random
+from typing import Dict
+
+from .satellites import LEOSatellite, MEOSatellite
+from .environment import find_nearest_available_leo
+from .rl_agent import RLAgent
+from .routing import route_request
+
+
+def build_example_network() -> tuple[Dict[int, LEOSatellite], Dict[int, MEOSatellite]]:
+    """Create a very small network for demonstration purposes."""
+    # Create MEO satellites
+    meos = {
+        1: MEOSatellite(id=1, latitude=0, longitude=0, altitude=20000, cluster_leos=[1, 2]),
+        2: MEOSatellite(id=2, latitude=10, longitude=10, altitude=20000, cluster_leos=[3, 4]),
+    }
+
+    # Create LEO satellites
+    leos = {
+        1: LEOSatellite(id=1, latitude=0, longitude=0, altitude=500, neighbors=[2], meo_id=1),
+        2: LEOSatellite(id=2, latitude=1, longitude=1, altitude=500, neighbors=[1], meo_id=1),
+        3: LEOSatellite(id=3, latitude=10, longitude=10, altitude=500, neighbors=[4], meo_id=2),
+        4: LEOSatellite(id=4, latitude=11, longitude=11, altitude=500, neighbors=[3], meo_id=2),
+    }
+    return leos, meos
+
+
+def main():
+    leos, meos = build_example_network()
+    agent = RLAgent()
+
+    ground_pos = (0.5, 0.5, 0)
+    load_threshold = 5
+    src_leo = find_nearest_available_leo(ground_pos, leos, load_threshold)
+
+    # Example: send request to LEO 4
+    path = route_request(src_leo.id, 4, leos, meos, agent)
+    print("Routing path:", path)
+
+
+if __name__ == "__main__":
+    random.seed(0)
+    main()

--- a/src/rl_agent.py
+++ b/src/rl_agent.py
@@ -1,0 +1,26 @@
+import random
+from typing import Dict, Tuple, List
+
+class RLAgent:
+    """Simple Q-learning agent for routing decisions."""
+
+    def __init__(self, learning_rate: float = 0.1, gamma: float = 0.9, epsilon: float = 0.1):
+        self.lr = learning_rate
+        self.gamma = gamma
+        self.epsilon = epsilon
+        self.q_table: Dict[Tuple[int, int], Dict[int, float]] = {}
+
+    def choose_action(self, state: Tuple[int, int], actions: List[int]) -> int:
+        self.q_table.setdefault(state, {a: 0.0 for a in actions})
+        if random.random() < self.epsilon:
+            return random.choice(actions)
+        # choose action with max Q value
+        return max(actions, key=lambda a: self.q_table[state].get(a, 0.0))
+
+    def update(self, state: Tuple[int, int], action: int, reward: float, next_state: Tuple[int, int], next_actions: List[int]):
+        self.q_table.setdefault(state, {})
+        self.q_table[state].setdefault(action, 0.0)
+        self.q_table.setdefault(next_state, {a: 0.0 for a in next_actions})
+        max_next = max(self.q_table[next_state].values(), default=0.0)
+        old_value = self.q_table[state][action]
+        self.q_table[state][action] = old_value + self.lr * (reward + self.gamma * max_next - old_value)

--- a/src/routing.py
+++ b/src/routing.py
@@ -1,0 +1,57 @@
+from typing import Dict, List
+
+from .satellites import LEOSatellite, MEOSatellite
+from .environment import get_leo_by_id, get_meo_by_id
+from .rl_agent import RLAgent
+
+
+def route_request(
+    src_leo_id: int,
+    dst_leo_id: int,
+    leos: Dict[int, LEOSatellite],
+    meos: Dict[int, MEOSatellite],
+    agent: RLAgent,
+) -> List[int]:
+    """Return list of LEO ids representing the path."""
+    src_leo = get_leo_by_id(leos, src_leo_id)
+    dst_leo = get_leo_by_id(leos, dst_leo_id)
+    path = [src_leo.id]
+
+    # If in the same MEO cluster, use RL to find path via neighbors
+    if src_leo.meo_id == dst_leo.meo_id:
+        current = src_leo.id
+        while current != dst_leo.id:
+            current_leo = get_leo_by_id(leos, current)
+            actions = current_leo.neighbors
+            state = (current, dst_leo.id)
+            next_action = agent.choose_action(state, actions)
+            path.append(next_action)
+            current = next_action
+    else:
+        # Different clusters: src -> src edge -> cross cluster -> dest
+        src_meo = get_meo_by_id(meos, src_leo.meo_id)
+        dst_meo = get_meo_by_id(meos, dst_leo.meo_id)
+        # choose edge nodes (simplified as first LEO in cluster list)
+        edge_src = src_meo.cluster_leos[0]
+        edge_dst = dst_meo.cluster_leos[0]
+        # path within src cluster
+        current = src_leo.id
+        while current != edge_src:
+            current_leo = get_leo_by_id(leos, current)
+            actions = current_leo.neighbors
+            state = (current, edge_src)
+            next_action = agent.choose_action(state, actions)
+            path.append(next_action)
+            current = next_action
+        # cross cluster via MEO satellites (abstracted as direct link)
+        path.append(edge_dst)
+        current = edge_dst
+        while current != dst_leo.id:
+            current_leo = get_leo_by_id(leos, current)
+            actions = current_leo.neighbors
+            state = (current, dst_leo.id)
+            next_action = agent.choose_action(state, actions)
+            path.append(next_action)
+            current = next_action
+
+    return path

--- a/src/satellites.py
+++ b/src/satellites.py
@@ -1,0 +1,22 @@
+from dataclasses import dataclass, field
+from typing import List
+
+@dataclass
+class Satellite:
+    """Base class for a satellite."""
+    id: int
+    latitude: float
+    longitude: float
+    altitude: float
+
+@dataclass
+class LEOSatellite(Satellite):
+    """Low Earth Orbit satellite."""
+    load: int = 0
+    neighbors: List[int] = field(default_factory=list)
+    meo_id: int = 0
+
+@dataclass
+class MEOSatellite(Satellite):
+    """Medium Earth Orbit satellite."""
+    cluster_leos: List[int] = field(default_factory=list)


### PR DESCRIPTION
## Summary
- implement basic satellite data structures and environment helpers
- add a simple Q-learning agent
- provide routing logic that can handle intra- and inter-cluster paths
- include a small runnable demo
- update README with instructions

## Testing
- `python -m src.main`

------
https://chatgpt.com/codex/tasks/task_e_6870e1db07748330be9e03a6c0f6e11b